### PR TITLE
bump compiler and drop plots

### DIFF
--- a/decorated-cospans.cabal
+++ b/decorated-cospans.cabal
@@ -23,7 +23,7 @@ source-repository head
 common common-options
   build-depends:
     , algebraic-graphs
-    , base                 ^>=4.13.0.0
+    , base                 ^>=4.14.0.0
     , bifunctors
     , containers
     , finitary
@@ -89,7 +89,6 @@ executable example-sir
     , hmatrix-gsl
     , hvega
     , knit-haskell       >=0.8.0.0
-    , plots
     , polysemy
     , polysemy-plugin
     , text

--- a/default.nix
+++ b/default.nix
@@ -26,5 +26,5 @@ in pkgs.haskell-nix.project {
     src = ./.;
   };
   # Specify the GHC version to use.
-  compiler-nix-name = "ghc884"; # Not required for `stack.yaml` based projects.
+  compiler-nix-name = "ghc8107"; # Not required for `stack.yaml` based projects.
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e17be32e5839457125ed81c52b10ab960a9e02bf",
-        "sha256": "1gz3rvkscrriqgbs5pknr3wh95l4mvh6vvm2xr584xc9qg78y3d7",
+        "rev": "b9b3904fc7d76f250e2530c85dedadf2c8e30beb",
+        "sha256": "0hhx38nww8mm1ffwckjr52x2svsbqqshgwsrf0smp4d8p5sn8wad",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/e17be32e5839457125ed81c52b10ab960a9e02bf.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/b9b3904fc7d76f250e2530c85dedadf2c8e30beb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
This bumps flakes and ghc to 8.10 and drops an unused dependency `plots`.